### PR TITLE
fix usage on help text from standalone mode

### DIFF
--- a/pyftpdlib/__main__.py
+++ b/pyftpdlib/__main__.py
@@ -59,7 +59,7 @@ class CustomizedOptionFormatter(optparse.IndentedHelpFormatter):
 
 def main():
     """Start a stand alone anonymous FTP server."""
-    usage = "python -m pyftpdlib.ftpserver [options]"
+    usage = "python -m pyftpdlib [options]"
     parser = optparse.OptionParser(usage=usage, description=main.__doc__,
                                    formatter=CustomizedOptionFormatter())
     parser.add_option('-i', '--interface', default=None, metavar="ADDRESS",


### PR DESCRIPTION
`python -m pyftpdlib.ftpserver` result in DeprecationWarning

Ex:

``` bash
python -m pyftpdlib.ftpserver
/usr/local/lib/python2.7/dist-packages/pyftpdlib/ftpserver.py:53: DeprecationWarning: pyftpdlib.ftpserver module is deprecated
  _depwarn("pyftpdlib.ftpserver module is deprecated")
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/usr/local/lib/python2.7/dist-packages/pyftpdlib/ftpserver.py", line 88, in <module>
    from pyftpdlib import main
ImportError: cannot import name main

```
