### PR TITLE
update log.py to be more explicit and compatible with fail2ban

### DIFF
--- a/pyftpdlib/log.py
+++ b/pyftpdlib/log.py
@@ -65,7 +65,7 @@ def _stderr_supports_color():
 LEVEL = logging.INFO
 PREFIX = '[%(levelname)1.1s %(asctime)s]'
 COLOURED = _stderr_supports_color()
-TIME_FORMAT = "%y-%m-%d %H:%M:%S"
+TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
 # taken and adapted from Tornado


### PR DESCRIPTION
fail2ban look for a date with year on 4 chars.
A date with 4 chars is also more explicit.