### PR TITLE
Uses _AsyncChatNewStyle for FTPHandler

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -1053,7 +1053,7 @@ class BufferedIteratorProducer(object):
 
 # --- FTP
 
-class FTPHandler(AsyncChat):
+class FTPHandler(_AsyncChatNewStyle):
     """Implements the FTP server Protocol Interpreter (see RFC-959),
     handling commands received from the client on the control channel.
 


### PR DESCRIPTION
FTPHandler was still using the old-style AsyncChat preventing usage of super(). I'm not sure why this was the case, but I see no need for the old-style and prefer to use super rather than directly calling the FTPHandler methods when subclassing.