### PR TITLE
Allow use of file-like objects without fileno

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -634,7 +634,8 @@ class DTPHandler(AsyncChat):
     def _use_sendfile(self, producer):
         return (self.cmd_channel.use_sendfile and
                 isinstance(producer, FileProducer) and
-                producer.type == 'i')
+                producer.type == 'i' and
+                hasattr(producer.file, 'fileno'))
 
     def push(self, data):
         self._initialized = True


### PR DESCRIPTION
When working with file-like objects without filenos, I'd get an error without this since files are expected to have a fileno method. This change checks for the existence of that method when deciding to use sendfile, and transmits it the regular way if the method is not present.

This change does not change any previous behaviour, it just adds the ability to serve file-like files without filenos. When using regular files, ie. files with fileno methods, nothing changes.