### PR TITLE
Include docs in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,5 @@ include README.rst
 recursive-include demo *.py *.pem *README*
 recursive-include pyftpdlib *.py *.pem *README*
 recursive-include scripts *
+recursive-exclude docs/_build *
+recursive-include docs *.rst *.js *.html *.py *.bat *Makefile* *README*


### PR DESCRIPTION
Hi, that would be really nice as we at Gentoo build docs from PyPI tarballs and these currently don't include the docs folder.