### PR TITLE
Fix incorrect behaviour if pysendfile is not installed on posix

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -674,6 +674,8 @@ class DTPHandler(AsyncChat):
                     raise _GiveUpOnSendfile
                 else:
                     raise
+        except TypeError as err:
+            raise _GiveUpOnSendfile
         else:
             if sent == 0:
                 # this signals the channel that the transfer is completed


### PR DESCRIPTION
The problem is that if pysendfile is not installed (and pysendfile is not in the required modules, so it may happen that user installs pyftpdlib, but doesn't install pysendfile), the global variable sendfile (line 75) is assigned value None (the result of the exection of a function _import_sendfile, lines 56-72). Later in initiate_send (line 663) we call sendfile(...), assuming that it is a function and get "TypeError: 'NoneType' object is not callable" exception which is not handled. I suggest adding extra "except" block in which we catch the exception and raise a different one, which would notify the caller that it should not try using "sendfile", but use "plain send" instead.