### PR TITLE
Close file handle before responding successfully to client. Fix #414

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,9 @@ Bug tracker at https://github.com/giampaolo/pyftpdlib/issues
 Version: 1.5.3 - XXXX-XX-XX
 ===========================
 
-XXX
+**Bug fixes**
+
+- #414: Respond successfully to STOR only after closing file handle.
 
 Version: 1.5.2 - 2017-04-06
 ===========================

--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -872,11 +872,14 @@ class DTPHandler(AsyncChat):
         if not self._closed:
             # RFC-959 says we must close the connection before replying
             AsyncChat.close(self)
+
+            # Close file object before responding successfully to client
+            if self.file_obj is not None and not self.file_obj.closed:
+                self.file_obj.close()
+                
             if self._resp:
                 self.cmd_channel.respond(self._resp[0], logfun=self._resp[1])
 
-            if self.file_obj is not None and not self.file_obj.closed:
-                self.file_obj.close()
             if self._idler is not None and not self._idler.cancelled:
                 self._idler.cancel()
             if self.file_obj is not None:


### PR DESCRIPTION
See #414 