### PR TITLE
update bench.py path in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ superior to most common UNIX FTP servers. It also scales better since whereas
 vsftpd and proftpd use multiple processes to achieve concurrency, pyftpdlib
 will only use one process and handle concurrency asynchronously (see
 `the C10K problem <http://www.kegel.com/c10k.html>`__). Here are some
-`benchmarks <https://github.com/giampaolo/pyftpdlib/blob/master/test/bench.py>`__
+`benchmarks <https://github.com/giampaolo/pyftpdlib/blob/master/scripts/ftpbench>`__
 made against my Linux 3.0.0 box, Intel core-duo 3.1 Ghz:
 
 pyftpdlib vs. proftpd 1.3.4

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -259,16 +259,16 @@ The following patch was applied first:
     $ sudo python demo/unix_daemon.py
 
 
-The `benchmark script <https://github.com/giampaolo/pyftpdlib/blob/master/test/bench.py>`__
+The `benchmark script <https://github.com/giampaolo/pyftpdlib/blob/master/scripts/ftpbench>`__
 was run as:
 
 ::
 
-    python test/bench.py -u USERNAME -p PASSWORD -b all -n 300
+    python scripts/ftpbench -u USERNAME -p PASSWORD -b all -n 300
 
 
 ...and for the memory test:
 
 ::
 
-    python test/bench.py -u USERNAME -p PASSWORD -b all -n 300 -k FTP_SERVER_PID
+    python scripts/ftpbench -u USERNAME -p PASSWORD -b all -n 300 -k FTP_SERVER_PID


### PR DESCRIPTION
The old URL: https://github.com/giampaolo/pyftpdlib/blob/master/test/bench.py gives 404.