### PR TITLE
Fix CR duplication in ASCII mode download

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -48,6 +48,12 @@ E: techtonik@gmail.com
 D: Inclusion of pyftpdlib in Far Manager, a file and archive manager for Windows
    http://www.farmanager.com/enforum/viewtopic.php?t=640&highlight=&sid=12d4d90f27f421243bcf7a0e3c516efb.
 
+N: Andrew Shulgin
+C: Ukraine
+E: andrewshulginua@gmail.com
+D: Fixing CR duplication in ASCII mode downloads.
+   https://github.com/giampaolo/pyftpdlib/pull/492
+
 N: Arkadiusz Wahlig
 C: Germany
 W: http://arkadiusz-wahlig.blogspot.com

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,12 @@
 Bug tracker at https://github.com/giampaolo/pyftpdlib/issues
 
+Version: 1.5.5 - 2019-03-27
+===========================
+
+**Bug fixes**
+
+- #492: CRLF line endings are replaced with CRCRLF in ASCII mode downloads.
+
 Version: 1.5.4 - 2018-05-04
 ===========================
 

--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -54,6 +54,8 @@ from .ioloop import timer
 from .log import debug
 from .log import logger
 
+CR_BYTE = ord('\r')
+
 
 def _import_sendfile():
     # By default attempt to use os.sendfile introduced in Python 3.3:
@@ -1047,8 +1049,8 @@ class FileProducer(object):
             pos = chunk.find(b'\n', pos)
             if pos == -1:
                 break
-            if chunk[pos - 1] != 13:
-                chunk.insert(pos, 13)
+            if chunk[pos - 1] != CR_BYTE:
+                chunk.insert(pos, CR_BYTE)
                 pos += 1
             pos += 1
         self._prev_chunk_endswith_cr = chunk.endswith(b'\r')

--- a/pyftpdlib/test/__init__.py
+++ b/pyftpdlib/test/__init__.py
@@ -37,10 +37,7 @@ if not hasattr(unittest.TestCase, "assertRaisesRegex"):
     unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
 if os.name == 'posix':
-    try:
-        import sendfile
-    except ImportError:
-        sendfile = None
+    import sendfile
 else:
     sendfile = None
 

--- a/pyftpdlib/test/__init__.py
+++ b/pyftpdlib/test/__init__.py
@@ -37,7 +37,10 @@ if not hasattr(unittest.TestCase, "assertRaisesRegex"):
     unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
 if os.name == 'posix':
-    import sendfile
+    try:
+        import sendfile
+    except ImportError:
+        sendfile = None
 else:
     sendfile = None
 

--- a/pyftpdlib/test/test_functional.py
+++ b/pyftpdlib/test/test_functional.py
@@ -67,10 +67,7 @@ except ImportError:
 import ssl
 
 if POSIX:
-    try:
-        import sendfile
-    except ImportError:
-        sendfile = None
+    import sendfile
 else:
     sendfile = None
 

--- a/pyftpdlib/test/test_functional.py
+++ b/pyftpdlib/test/test_functional.py
@@ -67,7 +67,10 @@ except ImportError:
 import ssl
 
 if POSIX:
-    import sendfile
+    try:
+        import sendfile
+    except ImportError:
+        sendfile = None
 else:
     sendfile = None
 
@@ -961,11 +964,23 @@ class TestFtpStoreDataNoSendfile(TestFtpStoreData):
 
 
 class TestFtpRetrieveData(unittest.TestCase):
-
-    "Test RETR, REST, TYPE"
+    """Test RETR, REST, TYPE"""
     server_class = MProcessTestFTPd
     client_class = ftplib.FTP
     use_sendfile = None
+
+    def retrieve_ascii(self, cmd, callback, blocksize=8192, rest=None):
+        """Like retrbinary but uses TYPE A instead."""
+        self.client.voidcmd('type a')
+        with contextlib.closing(
+                self.client.transfercmd(cmd, rest)) as conn:
+            conn.settimeout(TIMEOUT)
+            while True:
+                data = conn.recv(blocksize)
+                if not data:
+                    break
+                callback(data)
+        return self.client.voidresp()
 
     def setUp(self):
         self.server = self.server_class()
@@ -1006,30 +1021,29 @@ class TestFtpRetrieveData(unittest.TestCase):
                           "retr " + bogus, lambda x: x)
 
     def test_retr_ascii(self):
-        # Test RETR in ASCII mode.
-
-        def retrieve(cmd, callback, blocksize=8192, rest=None):
-            # like retrbinary but uses TYPE A instead
-            self.client.voidcmd('type a')
-            with contextlib.closing(
-                    self.client.transfercmd(cmd, rest)) as conn:
-                conn.settimeout(TIMEOUT)
-                while True:
-                    data = conn.recv(blocksize)
-                    if not data:
-                        break
-                    callback(data)
-            return self.client.voidresp()
+        """Test RETR in ASCII mode."""
 
         data = (b'abcde12345' + b(os.linesep)) * 100000
         self.file.write(data)
         self.file.close()
-        retrieve("retr " + TESTFN, self.dummyfile.write)
+        self.retrieve_ascii("retr " + TESTFN, self.dummyfile.write)
         expected = data.replace(b(os.linesep), b'\r\n')
         self.dummyfile.seek(0)
         datafile = self.dummyfile.read()
         self.assertEqual(len(expected), len(datafile))
         self.assertEqual(hash(expected), hash(datafile))
+
+    def test_retr_ascii_already_crlf(self):
+        """Test ASCII mode RETR for data with CRLF line endings."""
+
+        data = b'abcde12345\r\n' * 100000
+        self.file.write(data)
+        self.file.close()
+        self.retrieve_ascii("retr " + TESTFN, self.dummyfile.write)
+        self.dummyfile.seek(0)
+        datafile = self.dummyfile.read()
+        self.assertEqual(len(data), len(datafile))
+        self.assertEqual(hash(data), hash(datafile))
 
     @retry_on_failure()
     def test_restore_on_retr(self):


### PR DESCRIPTION
If a file has CRLF already, LF has been still replaced by CRLF, which resulted in CRCRLF line endings.