### PR TITLE
delete channel after socket is closed, fix #481

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -312,6 +312,7 @@ class PassiveDTP(Acceptor):
             # dual stack IPv4/IPv6 support
             af = self.bind_af_unspecified((local_ip, 0))
             self.socket.close()
+            self.del_channel()
         else:
             af = self.cmd_channel.socket.family
 


### PR DESCRIPTION
`self.create_socket` is not guaranteed to be assigned to the same `fd` as `self.bind_af_unspecified`.

If they are different, there is a closed socket in `Select._r` and the bug occurs.