### PR TITLE
Allow MFMT to work on directories as well

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -2719,8 +2719,8 @@ class FTPHandler(AsyncChat):
             why = "Invalid time format; expected: YYYYMMDDHHMMSS"
             self.respond('550 %s.' % why)
             return
-        if not self.fs.isfile(self.fs.realpath(path)):
-            self.respond("550 %s is not retrievable" % line)
+        if not self.fs.lexists(self.fs.realpath(path)):
+            self.respond("550 No such file or directory.")
             return
         if self.use_gmt_times:
             timefunc = time.gmtime


### PR DESCRIPTION
I have a user who needs to be able to use MFMT on a directory and before the patch, this happens:

lftp guppy@example.com:/> quote mfmt 20190101010100 ftp_test
550 /ftp_test is not retrievable                  

After the fix:

lftp guppy@example.com:/> quote mfmt 20190101010100 ftp_test
213 Modify=20190101010100; /ftp_test.

And on something that doesn't exist:

lftp guppy@example.com:/> quote mfmt 20190101010100 blahblah
550 No such file or directory.