### PR TITLE
Cache username/groupname results on LIST

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,12 +1,13 @@
 Bug tracker at https://github.com/giampaolo/pyftpdlib/issues
 
-Version: 1.5.6 - XXXX-XX-XX
+Version: 1.5.6 - 2020-02-16
 ===========================
 
 **Enhancements**
 
 - #467: added pre-fork concurrency model, spawn()ing worker processes to split
   load.
+- #520: directory LISTing is now 3.7x times faster.
 
 Version: 1.5.5 - 2019-04-04
 ===========================


### PR DESCRIPTION
When LISTing a directory we call `pwd.getpwuid` and `grp.getgrgid` repeatedly. This patch avoids that by using a `memoize` decorator caching results.  This simple benchmark reports a +3.7x speedup when listing a directory via LIST:

```python
from pyftpdlib.handlers import FTPHandler
from pyftpdlib.filesystems import AbstractedFS
import os
import time

here = os.getcwd()
fs = AbstractedFS(here, FTPHandler)
t = time.time()
for x in range(1000):
    list(fs.format_list(here, os.listdir(here)))
print(time.time() - t)
``` 

Before: 1.3308672904968262
After: 0.35703492164611816

Directory had 38 files, meaning in my system I'm able to list 38 * 1000 = 38000 files in 0.35 secs instead of 1.33.