### PR TITLE
Uppercased first letters for PASV response

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -367,7 +367,7 @@ class PassiveDTP(Acceptor):
                 ip = ip[7:]
             # The format of 227 response in not standardized.
             # This is the most expected:
-            resp = '227 Entering passive mode (%s,%d,%d).' % (
+            resp = '227 Entering Passive Mode (%s,%d,%d).' % (
                 ip.replace('.', ','), port // 256, port % 256)
             self.cmd_channel.respond(resp)
         else:


### PR DESCRIPTION
Replaced the PASV response "227 Entering passive mode" with "227 Entering Passive Mode" (uppercased first letters).

This fixes a problem where some FTP clients would not send data, because they expected the casing to match.