### PR TITLE
Include fileno() in try-except, to support custom IO

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -633,6 +633,11 @@ class DTPHandler(AsyncChat):
         if self.file_obj is None or not hasattr(self.file_obj, "fileno"):
             # directory listing or unusual file obj
             return False
+        try:
+            # io.IOBase default implementation raises io.UnsupportedOperation
+            self.file_obj.fileno()
+        except OSError:
+            return False
         if self.cmd_channel._current_type != 'i':
             # text file transfer (need to transform file content on the fly)
             return False

--- a/pyftpdlib/test/test_functional.py
+++ b/pyftpdlib/test/test_functional.py
@@ -7,6 +7,7 @@
 import contextlib
 import errno
 import ftplib
+import io
 import logging
 import os
 import random
@@ -636,11 +637,28 @@ class TestFtpFsOperations(TestCase):
                 self.assertEqual(getmode(), '0555')
 
 
+class CustomIO(io.RawIOBase):
+
+    def __init__(self):
+        super(CustomIO, self).__init__()
+        self._bytesio = io.BytesIO()
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        return self._bytesio.seek(offset, whence)
+
+    def readinto(self, b):
+        return self._bytesio.readinto(b)
+
+    def write(self, b):
+        return self._bytesio.write(b)
+
+
 class TestFtpStoreData(TestCase):
     """Test STOR, STOU, APPE, REST, TYPE."""
     server_class = MProcessTestFTPd
     client_class = ftplib.FTP
     use_sendfile = None
+    use_custom_io = False
 
     def setUp(self):
         self.server = self.server_class()
@@ -650,8 +668,12 @@ class TestFtpStoreData(TestCase):
         self.client = self.client_class(timeout=TIMEOUT)
         self.client.connect(self.server.host, self.server.port)
         self.client.login(USER, PASSWD)
-        self.dummy_recvfile = BytesIO()
-        self.dummy_sendfile = BytesIO()
+        if self.use_custom_io:
+            self.dummy_recvfile = CustomIO()
+            self.dummy_sendfile = CustomIO()
+        else:
+            self.dummy_recvfile = BytesIO()
+            self.dummy_sendfile = BytesIO()
         self.testfn = self.get_testfn()
 
     def tearDown(self):
@@ -921,11 +943,17 @@ class TestFtpStoreDataNoSendfile(TestFtpStoreData):
     use_sendfile = False
 
 
+class TestFtpStoreDataWithCustomIO(TestFtpStoreData):
+    """Test STOR, STOU, APPE, REST, TYPE with custom IO objects()."""
+    use_custom_io = True
+
+
 class TestFtpRetrieveData(TestCase):
     """Test RETR, REST, TYPE"""
     server_class = MProcessTestFTPd
     client_class = ftplib.FTP
     use_sendfile = None
+    use_custom_io = False
 
     def retrieve_ascii(self, cmd, callback, blocksize=8192, rest=None):
         """Like retrbinary but uses TYPE A instead."""
@@ -949,7 +977,10 @@ class TestFtpRetrieveData(TestCase):
         self.client.connect(self.server.host, self.server.port)
         self.client.login(USER, PASSWD)
         self.testfn = self.get_testfn()
-        self.dummyfile = BytesIO()
+        if self.use_custom_io:
+            self.dummyfile = CustomIO()
+        else:
+            self.dummyfile = BytesIO()
 
     def tearDown(self):
         close_client(self.client)
@@ -1048,6 +1079,11 @@ class TestFtpRetrieveData(TestCase):
 class TestFtpRetrieveDataNoSendfile(TestFtpRetrieveData):
     """Test RETR, REST, TYPE by not using sendfile()."""
     use_sendfile = False
+
+
+class TestFtpRetrieveDataCustomIO(TestFtpRetrieveData):
+    """Test RETR, REST, TYPE using custom IO objects."""
+    use_custom_io = True
 
 
 class TestFtpListingCmds(TestCase):


### PR DESCRIPTION
Currently, pyftpdlib tests for `sendfile()` support on a file object by testing for the existence of a `fileno` attribute. This is appropriate for some abstract IO objects like `BytesIO`.

However, for complex IO objects which inherit from `io.IOBase`, the `fileno()` method always exists but raises `io.UnsupportedOperation` when called. pyftpdlib thinks the object supports sendfile but crashes when calling the method.

(the `io` module APIs are a convoluted mess, which creates this confusion in the first place, but it's also why inheriting from their base objects is the most reliable way to ensure conformance)

My use case is that I'm writing an FTP server that accesses bittorrent data downloaded on demand, instead of the server's filesystem. I do this by creating objects which inherit from `io.BufferedIOBase` and feeding them to pyftpdlib. Currently, I need to disable sendfile globally by setting `handler.use_sendfile = False`. This is fine for now, but I will likely want to intermix sendfile- and non-sendfile IO objects in the future, due to some variance in how I can access data from libtorrent.

This fix just puts the call to `fileno()` inside the try-except around sendfile, so it can use the fallback to regular send.