### PR TITLE
Update handlers.py

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -305,8 +305,11 @@ class PassiveDTP(Acceptor):
         Acceptor.__init__(self, ioloop=cmd_channel.ioloop)
 
         local_ip = self.cmd_channel.socket.getsockname()[0]
+        client_ip = self.cmd_channel.remote_ip
         if local_ip in self.cmd_channel.masquerade_address_map:
             masqueraded_ip = self.cmd_channel.masquerade_address_map[local_ip]
+        elif client_ip in self.cmd_channel.masquerade_address_map:
+            masqueraded_ip = self.cmd_channel.masquerade_address_map[client_ip]
         elif self.cmd_channel.masquerade_address:
             masqueraded_ip = self.cmd_channel.masquerade_address
         else:


### PR DESCRIPTION
masquerade_address_map add client IP support.
masquerade_address_map = {'2.2.2.1':'2.2.2.1',**'4.4.4.1':'3.3.3.1'**}

client-A -> nat device -> ftp server <- route <- client-B
1.1.1.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2.2.2.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3.3.3.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4.4.4.1

Signed-off-by: nmweizi <nmweizi@gmail.com>