### PR TITLE
Add Python versions to GHA Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: ["2.7", "3.9"]
+        python-version: ["2.7", "3.8", "3.9", "3.10"]
 
     steps:
       #


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

Win 3.7 fails with

```
FAIL: pyftpdlib.test.test_filesystems.TestAbstractedFS.test_validpath_external_symlink
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\site-packages\pyftpdlib-1.5.8-py3.7.egg\pyftpdlib\test\test_filesystems.py", line 195, in test_validpath_external_symlink
    self.assertFalse(fs.validpath(u(testfn)))
AssertionError: True is not false
```