### PR TITLE
Speedup logging by 28%

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install test deps
         if: matrix.python-version == 2.7
         run: |
-          make setup-test-env PYTHON=python
+          make setup-dev-env PYTHON=python
       #
       - name: Lint
         if: matrix.python-version != 2.7

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,8 @@ Version: 1.5.8 - IN DEVELOPMENT
 **Enhancements**
 
 - #586: removed Python 2.6 support.
-
+- #591: speedup logging by 28% by using `logging._srcfile = None` trick. This
+  avoids calling `calling sys._getframe()` for each log record.
 
 Version: 1.5.7 - 2022-10-04
 ===========================

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean:  ## Remove all build files.
 		*\$testfile* \
 		.coverage \
 		.tox \
-		pyftpd-tmp-\* \
+		pyftpd-tmp-* \
 		build/ \
 		dist/ \
 		docs/_build/ \
@@ -89,14 +89,12 @@ install-pip:  ## (only if necessary)
 		f.close(); \
 		sys.exit(code);"
 
-setup-test-env:  ## Install GIT hooks, pip, test deps (also upgrades them).
+setup-dev-env: ## Install GIT hooks, pip, test deps (also upgrades them).
 	${MAKE} install-git-hooks
 	${MAKE} install-pip
 	$(PYTHON) -m pip install $(INSTALL_OPTS) --upgrade pip setuptools
-	$(PYTHON) -m pip install $(INSTALL_OPTS) --upgrade $(TEST_DEPS)
-
-setup-dev-env: setup-test-env
 	$(PYTHON) -m pip install $(INSTALL_OPTS) --upgrade $(DEV_DEPS)
+	$(PYTHON) -m pip install $(INSTALL_OPTS) --upgrade $(TEST_DEPS)
 
 # ===================================================================
 # Tests

--- a/pyftpdlib/log.py
+++ b/pyftpdlib/log.py
@@ -149,12 +149,12 @@ def is_logging_configured():
 # TODO: write tests
 
 def config_logging(level=LEVEL, prefix=PREFIX, other_loggers=None):
-    # Speedup logging by preventing certain log record info to be
-    # fetched, see:
+    # Speedup logging by preventing certain internal log record info to
+    # be unnecessarily fetched, see:
     # https://docs.python.org/3/howto/logging.html#optimization
-    # https://docs.python.org/3/library/logging.html#logrecord-attributes
-    # https://stackoverflow.com/a/38924153/376587
-    # This results in about 28% speedup.
+    # https://docs.python.org/3/library/logging.html#logrecord-
+    # attributes https://stackoverflow.com/a/38924153/376587 This
+    # results in about 28% speedup.
     key_names = re.findall(
         r'(?<!%)%\(([^)]+)\)[-# +0-9.hlL]*[diouxXeEfFgGcrs]', prefix)
     if "process" not in key_names:
@@ -167,6 +167,7 @@ def config_logging(level=LEVEL, prefix=PREFIX, other_loggers=None):
             "pathname" not in key_names and \
             "lineno" not in key_names and \
             "module" not in key_names:
+        # biggest speedup as it avoids calling sys._getframe()
         logging._srcfile = None
     handler = logging.StreamHandler()
     formatter = LogFormatter()

--- a/pyftpdlib/log.py
+++ b/pyftpdlib/log.py
@@ -149,7 +149,8 @@ def is_logging_configured():
 # TODO: write tests
 
 def config_logging(level=LEVEL, prefix=PREFIX, other_loggers=None):
-    # Speedup logging by disabling log record info to be fetched, see:
+    # Speedup logging by preventing certain log record info to be
+    # fetched, see:
     # https://docs.python.org/3/howto/logging.html#optimization
     # https://docs.python.org/3/library/logging.html#logrecord-attributes
     # https://stackoverflow.com/a/38924153/376587

--- a/pyftpdlib/log.py
+++ b/pyftpdlib/log.py
@@ -150,11 +150,10 @@ def is_logging_configured():
 
 def config_logging(level=LEVEL, prefix=PREFIX, other_loggers=None):
     # Speedup logging by preventing certain internal log record info to
-    # be unnecessarily fetched, see:
-    # https://docs.python.org/3/howto/logging.html#optimization
-    # https://docs.python.org/3/library/logging.html#logrecord-
-    # attributes https://stackoverflow.com/a/38924153/376587 This
-    # results in about 28% speedup.
+    # be unnecessarily fetched. This results in about 28% speedup. See:
+    # * https://docs.python.org/3/howto/logging.html#optimization
+    # * https://docs.python.org/3/library/logging.html#logrecord-attributes
+    # * https://stackoverflow.com/a/38924153/376587
     key_names = re.findall(
         r'(?<!%)%\(([^)]+)\)[-# +0-9.hlL]*[diouxXeEfFgGcrs]', prefix)
     if "process" not in key_names:
@@ -169,6 +168,7 @@ def config_logging(level=LEVEL, prefix=PREFIX, other_loggers=None):
             "module" not in key_names:
         # biggest speedup as it avoids calling sys._getframe()
         logging._srcfile = None
+
     handler = logging.StreamHandler()
     formatter = LogFormatter()
     formatter.PREFIX = prefix


### PR DESCRIPTION
Speedup logging by ~28%. From https://docs.python.org/3/howto/logging.html#optimization:

> Set logging._srcfile to None. This avoids calling [sys._getframe()](https://docs.python.org/3/library/sys.html#sys._getframe), which may help to speed up your code in environments like PyPy (which can’t speed up code that uses [sys._getframe()](https://docs.python.org/3/library/sys.html#sys._getframe)).

Benchmark script:

```python
from pyftpdlib.log import config_logging, logger
config_logging()
for x in range(100000):
    logger.error("ciao")
```
Before patch:

```
~/svn/pyftpdlib {master}$ time python3 foo.py &> /dev/null
real    0m1,838s
user    0m1,726s
sys     0m0,106s
```

After patch:

```
~/svn/pyftpdlib {master}$ time python3 foo.py &> /dev/null
real    0m1,381s
user    0m1,288s
sys     0m0,093s
```
