### PR TITLE
Redecode homedir after os.path.realpath

### DIFF
--- a/pyftpdlib/authorizers.py
+++ b/pyftpdlib/authorizers.py
@@ -105,6 +105,8 @@ class DummyAuthorizer(object):
         if not os.path.isdir(homedir):
             raise ValueError('no such directory: %r' % homedir)
         homedir = os.path.realpath(homedir)
+        if isinstance(homedir, bytes):
+            homedir = homedir.decode('utf8')
         self._check_permissions(username, perm)
         dic = {'pwd': str(password),
                'home': homedir,


### PR DESCRIPTION
Because os.path.realpath can return bytes

---

issue: on Python2 this warning is printed even if the homedir argument is unicode:

```
  /opt/lib/python2.7/site-packages/pyftpdlib/handlers.py:2530: RuntimeWarning: DummyAuthorizerWithUnicodeHomeDir.get_home_dir returned a non-unicode string; now casting to unicode
    RuntimeWarning)
```