### PR TITLE
Always 200 for OPTS UTF8 or OPTS UTF-8 ON

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -2992,12 +2992,14 @@ class FTPHandler(AsyncChat):
             if line.count(' ') > 1:
                 raise ValueError('Invalid number of arguments')
             if ' ' in line:
-                cmd, arg = line.split(' ')
-                if ';' not in arg:
-                    raise ValueError('Invalid argument')
+                cmd, arg = line.split(' ') 
             else:
                 cmd, arg = line, ''
-            # actually the only command able to accept options is MLST
+            if cmd.upper() in ("UTF8", "UTF-8"):
+                self.respond('200 Always in UTF8 mode.')
+                return
+            if arg and ';' not in arg:
+                    raise ValueError('Invalid argument') 
             if cmd.upper() != 'MLST' or 'MLST' not in self.proto_cmds:
                 raise ValueError('Unsupported command "%s"' % cmd)
         except ValueError as err:


### PR DESCRIPTION
Fix #266 and #531.
Took inspiration from vsftpd for 200 reply message - https://github.com/dagwieers/vsftpd/blob/ce2fa4288b92683f832c3b5179d5cb2a77d0750e/opts.c#L20

Let me know if additional changes are needed in order to merge it.