### PR TITLE
Fixes in DTPHandler.use_sendfile and Epoll.poll

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,11 @@ Version: 1.5.8 - IN DEVELOPMENT
   avoids calling `calling sys._getframe()` for each log record.
 - #605: added support for Python 3.12.
 
+**Bug fixes**
+
+- #607: possible infinite wait in Epoll
+- #607: possible infinite traceback printing in DTPHandler
+
 Version: 1.5.7 - 2022-10-04
 ===========================
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,16 @@
 Bug tracker at https://github.com/giampaolo/pyftpdlib/issues
 
-Version: 1.5.8 - IN DEVELOPMENT
+Version: 1.5.9 - IN DEVELOPMENT
 ===============================
+
+**Bug fixes**
+
+- #607: possible infinite wait in Epoll  (patch by @stat1c-void)
+- #607: possible infinite traceback printing in DTPHandler  (patch by 
+  @stat1c-void)
+
+Version: 1.5.8 - 2023-10-02
+===========================
 
 **Enhancements**
 
@@ -9,11 +18,6 @@ Version: 1.5.8 - IN DEVELOPMENT
 - #591: speedup logging by 28% by using `logging._srcfile = None` trick. This
   avoids calling `calling sys._getframe()` for each log record.
 - #605: added support for Python 3.12.
-
-**Bug fixes**
-
-- #607: possible infinite wait in Epoll
-- #607: possible infinite traceback printing in DTPHandler
 
 Version: 1.5.7 - 2022-10-04
 ===========================

--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -639,8 +639,11 @@ class DTPHandler(AsyncChat):
             return False
         try:
             # io.IOBase default implementation raises io.UnsupportedOperation
+            # UnsupportedOperation inherits ValueError
+            # also may raise ValueError if stream is closed
+            # https://docs.python.org/3/library/io.html#io.IOBase
             self.file_obj.fileno()
-        except OSError:
+        except ValueError:
             return False
         if self.cmd_channel._current_type != 'i':
             # text file transfer (need to transform file content on the fly)

--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -643,7 +643,7 @@ class DTPHandler(AsyncChat):
             # also may raise ValueError if stream is closed
             # https://docs.python.org/3/library/io.html#io.IOBase
             self.file_obj.fileno()
-        except ValueError:
+        except (OSError, ValueError):
             return False
         if self.cmd_channel._current_type != 'i':
             # text file transfer (need to transform file content on the fly)

--- a/pyftpdlib/ioloop.py
+++ b/pyftpdlib/ioloop.py
@@ -523,8 +523,10 @@ class _BasePollEpoll(_IOLoop):
                 raise
 
     def poll(self, timeout):
+        if timeout is None:
+            timeout = -1  # -1 waits indefinitely
         try:
-            events = self._poller.poll(timeout or -1)  # -1 waits indefinitely
+            events = self._poller.poll(timeout)
         except (IOError, select.error) as err:
             # for epoll() and poll() respectively
             if err.errno == errno.EINTR:


### PR DESCRIPTION
Hi!

Thanks for your awesome work on `pyftpdlib`!

Here are two fixes, quite important in some cases, gathered from our production experience.

### 1. DTPHandler.use_sendfile

In one rare case in our environment pyftpdlib went into an infinite traceback printing loop.

May be a rare thing, I suspect it was mainly because of our environment: filesystem is a NAS-backed NFS, so things happen. Basically, it went something like this from my understanding:
1. event loop tries to close a connection
2. it then tries to close opened file, but fails to do so
3. during error handling and logging, calls `get_repr_info() -> use_sendfile() -> fileno()`
4. `fileno()` raises `ValueError`, which is not caught, and overall the event is not processed
5. same event tries to get processed the next tick of event loop, with similar result

This was happening many times per second. I'm going to attach a relevant traceback.

### 2. Epoll.poll

In some cases I observed infinite hanging of a connection thread. Basically, in some cases `Epoll.poll()` gets called with `timeout = 0`, but it causes it to call `self._poller.poll(-1)`. At the same time there are no more events on the socket. The timeout idler should have triggered, but the thread (we use threaded server) is stuck on `poll(-1)`.

I guess zero timeout comes from `_Scheduler.poll` when the top-most task is overdue:
```
return max(0, self._tasks[0].timeout - now)
```

Here is a `pystack` snapshot from our production env:

```
Traceback for thread 30 (python) [] (most recent call last):
    (Python) File "/usr/local/lib/python3.10/threading.py", line 973, in _bootstrap
        self._bootstrap_inner()
      Arguments:
        self: <Thread at 0x7f0c68e16440>
    (Python) File "/usr/local/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
        self.run()
      Arguments:
        self: <Thread at 0x7f0c68e16440>
    (Python) File "/usr/local/lib/python3.10/threading.py", line 953, in run
        self._target(*self._args, **self._kwargs)
      Arguments:
        self: <Thread at 0x7f0c68e16440>
    (Python) File "/usr/src/app/.venv/lib/python3.10/site-packages/pyftpdlib/servers.py", line 402, in _loop
        poll(timeout=soonest_timeout)
      Arguments:
        handler: <OVFXHandler at 0x7f0c6a23d5a0>
        self: <ThreadedFTPServer at 0x7f0c6a312170>
      Locals:
        poll_timeout: 1
        soonest_timeout: 0
        sched_poll: <method at 0x7f0c67f27500>
        poll: <method at 0x7f0c67f25b40>
        ioloop: <Epoll at 0x7f0c6961bd30>
    (Python) File "/usr/src/app/.venv/lib/python3.10/site-packages/pyftpdlib/ioloop.py", line 521, in poll
        events = self._poller.poll(timeout or -1)  # -1 waits indefinitely
      Arguments:
        timeout: 0
        self: <Epoll at 0x7f0c6961bd30>
```