### PR TITLE
fix get_repr_info

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -1342,8 +1342,11 @@ class FTPHandler(AsyncChat):
             if dc.file_obj:
                 if self.data_channel.receive:
                     info['sending-file'] = dc.file_obj
-                    if dc.use_sendfile():
-                        info['use-sendfile(2)'] = True
+                    try:
+                        if dc.use_sendfile():
+                            info['use-sendfile(2)'] = True
+                    except Exception as e:
+                        logger.warning(e)
                 else:
                     info['receiving-file'] = dc.file_obj
                 info['bytes-trans'] = dc.get_transmitted_bytes()


### PR DESCRIPTION
I found that the bug below occurred. This error occurs indefinitely.
```
2023-09-11 00:00:03     1|MainThread|CRITI|         handlers.py:1588 - Traceback (most recent call last):
  File "/usr/local/lib/python3.10/asyncore.py", line 90, in read
    obj.handle_read_event()
  File "/usr/local/lib/python3.10/asyncore.py", line 427, in handle_read_event
    self.handle_read()
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/ioloop.py", line 922, in handle_read
    asynchat.async_chat.handle_read(self)
  File "/usr/local/lib/python3.10/asynchat.py", line 125, in handle_read
    data = self.recv(self.ac_in_buffer_size)
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/ioloop.py", line 915, in recv
    self.handle_close()
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/handlers.py", line 1591, in handle_close
    self.close()
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/handlers.py", line 1595, in close
    debug("call: close()", inst=self)
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/log.py", line 135, in debug
    s += " (%r)" % inst
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/handlers.py", line 1356, in __repr__
    return '<%s(%s)>' % (self.__class__.__name__, self.get_repr_info(True))
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/handlers.py", line 1345, in get_repr_info
    if dc.use_sendfile():
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/handlers.py", line 642, in use_sendfile
    self.file_obj.fileno()
ValueError: I/O operation on closed file

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/handlers.py", line 1586, in handle_error
    self.close()
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/handlers.py", line 1595, in close
    debug("call: close()", inst=self)
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/log.py", line 135, in debug
    s += " (%r)" % inst
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/handlers.py", line 1356, in __repr__
    return '<%s(%s)>' % (self.__class__.__name__, self.get_repr_info(True))
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/handlers.py", line 1345, in get_repr_info
    if dc.use_sendfile():
  File "/opt/venv/lib/python3.10/site-packages/pyftpdlib/handlers.py", line 642, in use_sendfile
    self.file_obj.fileno()
ValueError: I/O operation on closed file
```

I don't know the exact cause, but I made an exception to the error in the log recording part.
Please review that part.
