### PR TITLE
Inherit IOLoop class in handlers

### DIFF
--- a/pyftpdlib/ioloop.py
+++ b/pyftpdlib/ioloop.py
@@ -300,6 +300,11 @@ class _IOLoop(object):
                 if cls._instance is None:
                     cls._instance = cls()
         return cls._instance
+    
+    @classmethod
+    def factory(cls):
+        """Constructs a new IOLoop instance."""
+        return cls()
 
     def register(self, fd, instance, events):
         """Register a fd, handled by instance for the given events."""

--- a/pyftpdlib/servers.py
+++ b/pyftpdlib/servers.py
@@ -375,7 +375,7 @@ class _SpawnerBase(FTPServer):
 
     def _loop(self, handler):
         """Serve handler's IO loop in a separate thread or process."""
-        with IOLoop() as ioloop:
+        with self.ioloop.factory() as ioloop:
             handler.ioloop = ioloop
             try:
                 handler.add_channel()


### PR DESCRIPTION
This change allows `FTPHandler` to inherit a concrete `IOLoop` class from `FTPServer`. Without it, it makes customizing an IOLoop harder than it needs to be: any custom IOLoop passed to `FTPServer` does not get inherited by handlers right now, because of this (`_SpawnerBase` in `servers.py`):

```python
    def _loop(self, handler):
        """Serve handler's IO loop in a separate thread or process."""
        with IOLoop() as ioloop:
```

### Other approaches

This looks ugly and makes assumptions about the constuctor:
```patch

    def _loop(self, handler):
        """Serve handler's IO loop in a separate thread or process."""
-       with IOLoop() as ioloop:
+       with self.ioloop.__class__() as ioloop:
```

Another one is to introduce a new `FTPServer` argument `ioloop_factory` - a callable factory.
```patch

    def _loop(self, handler):
        """Serve handler's IO loop in a separate thread or process."""
-       with IOLoop() as ioloop:
+       with self.ioloop_factory() as ioloop:
```

### Tests

Linux, Python 3.10.12.

```
Ran 795 tests in 28.538s

OK (skipped=55)
```