### PR TITLE
fix: SSLConnection is readable when it's accepting

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -3145,7 +3145,7 @@ if SSL is not None:
             self._ssl_want_write = False
 
         def readable(self):
-            return self._ssl_want_read or super().readable()
+            return self._ssl_accepting or self._ssl_want_read or super().readable()
 
         def writable(self):
             return self._ssl_want_write or super().writable()


### PR DESCRIPTION
ftps broke with recent curl clients (exact version unknown), due to pyftpdlib closing the dtp connection during the handshake via `DTPHandler.readable()` as the `DTPHandler` was not supposed to be readable yet. But the `SSLConnection` is accepting in this state, so it should be readable as far as I understand.

Example error:
```
# curl -v -k --ssl-reqd ftp://*****:*****@n10:2021/v0000/foo
*   Trying 27.1.0.10:2021...
* Connected to n10 (27.1.0.10) port 2021
< 220 ftp ready.
> AUTH SSL
< 234 AUTH SSL successful.
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* Server certificate:
* -----
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
> USER *****
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
< 331 Username ok, send password.
> PASS *****
< 230 Login successful.
> PBSZ 0
< 200 PBSZ=0 successful.
> PROT P
< 200 Protection set to Private
> PWD
< 257 "/" is the current directory.
* Entry path is '/'
> CWD v0000
* ftp_perform ends with SECONDARY: 0
< 250 "/v0000" is the current directory.
> EPSV
* Connect data stream passively
< 229 Entering extended passive mode (|||65330|).
* Connecting to 27.1.0.10 (27.1.0.10) port 65330
*   Trying 27.1.0.10:65330...
* Connected to n10 (27.1.0.10) port 2021
* SSL reusing session ID
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
> TYPE I
* Recv failure: Connection reset by peer
* OpenSSL SSL_connect: Connection reset by peer in connection to n10:2021 
* Failed EPSV attempt. Disabling EPSV
> PASV
< 200 Type set to: Binary.
* Bad PASV/EPSV response: 200
* Remembering we are in dir "v0000/"
* Connection #0 to host n10 left intact
curl: (13) Bad PASV/EPSV response: 200
```

Fixes: #604