### PR TITLE
Bugfix for TLS disconnect causing 100% CPU usage

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -3591,6 +3591,10 @@ if SSL is not None:
                     return
             FTPHandler.process_command(self, cmd, *args, **kwargs)
 
+        def close(self):
+            SSLConnection.close(self)
+            FTPHandler.close(self)
+        
         # --- new methods
 
         def handle_failed_ssl_handshake(self):


### PR DESCRIPTION
(Python 3.11.4, pyftpdlib 1.5.8) TLS_FTPHandler(SSLConnection, FTPHandler) did not implement the close() method, so only the first parent's close() is called. Not calling close() on FTPHandler leads to infinite loop and 100% CPU usage though.