### PR TITLE
Fix whitespace lint error

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -3604,7 +3604,7 @@ if SSL is not None:
         def close(self):
             SSLConnection.close(self)
             FTPHandler.close(self)
-        
+
         # --- new methods
 
         def handle_failed_ssl_handshake(self):


### PR DESCRIPTION
https://github.com/giampaolo/pyftpdlib/actions/runs/6646201388/job/18059152931

```
make[1]: Entering directory '/home/runner/work/pyftpdlib/pyftpdlib'
pyftpdlib/handlers.py:3607:1: W293 [*] Blank line contains whitespace
Found 1 error.
```