### PR TITLE
handler process_command/3 replaces = in method name

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -1755,7 +1755,8 @@ class FTPHandler(AsyncChat):
         if self._closed:
             return
         self._last_response = ""
-        method = getattr(self, 'ftp_' + cmd.replace(' ', '_'))
+        method_name = 'ftp_' + cmd.replace(' ', '_').replace('=', '_')
+        method = getattr(self, method_name)
         method(*args, **kwargs)
         if self._last_response:
             code = int(self._last_response[:3])


### PR DESCRIPTION
e.g. the IBM z/OS mainframe FTP server uses a SITE command structure like:

```
SITE FILETYPE=JES
```