### PR TITLE
Improve reliability of BufferedIteratorProducer when handling strings

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -1263,14 +1263,14 @@ class BufferedIteratorProducer:
         """Attempt a chunk of data from iterator by calling
         its next() method different times.
         """
-        buffer = []
-        for _ in xrange(self.loops):
-            try:
-                buffer.append(next(self.iterator))
-            except StopIteration:
-                break
-        return b''.join(buffer)
-
+        if self.iterator:
+            buffer = next(self.iterator, None)
+            if buffer is not None:
+                # Convert buffer to bytes if it's a string
+                if isinstance(buffer, str):
+                    buffer = buffer.encode()
+                return buffer
+        return b''  # Return an empty bytes object when there's no more data
 
 # --- FTP
 


### PR DESCRIPTION
The implementation improves the existing code for the following reasons:
* The original code uses b''.join(buffer), which assumes that the buffer elements are bytes. If the iterator produces strings, this can lead to errors.
* The new code explicitly checks the type of buffer and converts it to bytes if necessary, ensuring correct handling of different data types.