### PR TITLE
Use argparse instead of optparse

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ Version: 1.5.10 - (UNRELEASED)
 **Enhancements**
 
 * #621: use black formatter.
+* #626: use argparse instead of deprecated optparse.
 
 Version: 1.5.9 - 2023-10-25
 ===========================

--- a/demo/unix_daemon.py
+++ b/demo/unix_daemon.py
@@ -30,9 +30,9 @@ Authors:
  - Giampaolo Rodola' - g.rodola <at> gmail.com
 """
 
+import argparse
 import atexit
 import errno
-import optparse
 import os
 import signal
 import sys
@@ -170,40 +170,45 @@ def main():
     global PID_FILE, LOG_FILE
     USAGE = "python3 [-p PIDFILE] [-l LOGFILE]\n\n"
     USAGE += "Commands:\n  - start\n  - stop\n  - status"
-    parser = optparse.OptionParser(usage=USAGE)
-    parser.add_option(
+
+    parser = argparse.ArgumentParser(usage=USAGE)
+    parser.add_argument(
         '-l', '--logfile', dest='logfile', help='the log file location'
     )
-    parser.add_option(
+    parser.add_argument(
         '-p',
         '--pidfile',
         dest='pidfile',
         default=PID_FILE,
-        help='file to store/retreive daemon pid',
+        help='file to store/retrieve daemon pid',
     )
-    options, args = parser.parse_args()
+    parser.add_argument(
+        'command',
+        nargs='?',
+        help='command to execute: start, stop, restart, status',
+    )
+
+    options = parser.parse_args()
 
     if options.pidfile:
         PID_FILE = options.pidfile
     if options.logfile:
         LOG_FILE = options.logfile
 
-    if not args:
+    if not options.command:
         server = get_server()
         server.serve_forever()
     else:
-        if len(args) != 1:
-            sys.exit('too many commands')
-        elif args[0] == 'start':
+        if options.command == 'start':
             daemonize()
-        elif args[0] == 'stop':
+        elif options.command == 'stop':
             stop()
-        elif args[0] == 'restart':
+        elif options.command == 'restart':
             try:
                 stop()
             finally:
                 daemonize()
-        elif args[0] == 'status':
+        elif options.command == 'status':
             status()
         else:
             sys.exit('invalid command')

--- a/pyftpdlib/__main__.py
+++ b/pyftpdlib/__main__.py
@@ -8,8 +8,8 @@ Start a stand alone anonymous FTP server from the command line as in:
 $ python3 -m pyftpdlib
 """
 
+import argparse
 import logging
-import optparse
 import os
 import sys
 
@@ -21,64 +21,50 @@ from .log import config_logging
 from .servers import FTPServer
 
 
-class CustomizedOptionFormatter(optparse.IndentedHelpFormatter):
-    """Formats options shown in help in a prettier way."""
-
-    def format_option(self, option):
-        result = []
-        opts = self.option_strings[option]
-        result.append('  %s\n' % opts)
-        if option.help:
-            help_text = '     %s\n\n' % self.expand_default(option)
-            result.append(help_text)
-        return ''.join(result)
-
-
-def main():
+def main(args=None):
     """Start a stand alone anonymous FTP server."""
     usage = "python3 -m pyftpdlib [options]"
-    parser = optparse.OptionParser(
+    parser = argparse.ArgumentParser(
         usage=usage,
         description=main.__doc__,
-        formatter=CustomizedOptionFormatter(),
     )
-    parser.add_option(
+    parser.add_argument(
         '-i',
         '--interface',
         default=None,
         metavar="ADDRESS",
         help="specify the interface to run on (default all interfaces)",
     )
-    parser.add_option(
+    parser.add_argument(
         '-p',
         '--port',
-        type="int",
+        type=int,
         default=2121,
         metavar="PORT",
         help="specify port number to run on (default 2121)",
     )
-    parser.add_option(
+    parser.add_argument(
         '-w',
         '--write',
         action="store_true",
         default=False,
         help="grants write access for logged in user (default read-only)",
     )
-    parser.add_option(
+    parser.add_argument(
         '-d',
         '--directory',
         default=getcwdu(),
         metavar="FOLDER",
         help="specify the directory to share (default current directory)",
     )
-    parser.add_option(
+    parser.add_argument(
         '-n',
         '--nat-address',
         default=None,
         metavar="ADDRESS",
         help="the NAT address to use for passive connections",
     )
-    parser.add_option(
+    parser.add_argument(
         '-r',
         '--range',
         default=None,
@@ -88,22 +74,22 @@ def main():
             "connections (e.g. -r 8000-9000)"
         ),
     )
-    parser.add_option(
+    parser.add_argument(
         '-D', '--debug', action='store_true', help="enable DEBUG logging level"
     )
-    parser.add_option(
+    parser.add_argument(
         '-v',
         '--version',
         action='store_true',
         help="print pyftpdlib version and exit",
     )
-    parser.add_option(
+    parser.add_argument(
         '-V',
         '--verbose',
         action='store_true',
         help="activate a more verbose logging",
     )
-    parser.add_option(
+    parser.add_argument(
         '-u',
         '--username',
         type=str,
@@ -114,7 +100,7 @@ def main():
             "if supplied)"
         ),
     )
-    parser.add_option(
+    parser.add_argument(
         '-P',
         '--password',
         type=str,
@@ -124,7 +110,7 @@ def main():
         ),
     )
 
-    options, args = parser.parse_args()
+    options = parser.parse_args(args=args)
     if options.version:
         sys.exit("pyftpdlib %s" % __ver__)
     if options.debug:
@@ -171,6 +157,8 @@ def main():
         ftpd.serve_forever(timeout=2 if os.name == 'nt' else None)
     finally:
         ftpd.close_all()
+    if args:  # only used in unit tests
+        return ftpd
 
 
 if __name__ == '__main__':

--- a/pyftpdlib/test/test_misc.py
+++ b/pyftpdlib/test/test_misc.py
@@ -16,6 +16,7 @@ except ImportError:
     from io import BytesIO
 
 import pyftpdlib
+from pyftpdlib import __ver__
 from pyftpdlib.__main__ import main
 from pyftpdlib._compat import PY3
 from pyftpdlib._compat import super
@@ -129,15 +130,11 @@ class TestCommandLineParser(PyftpdlibTestCase):
         with self.assertRaises(SystemExit):
             main(["-r", "yyy-zzz"])
 
-    def test_v_option(self):
-        sys.argv += ["-v"]
-        self.assertRaises(SystemExit, pyftpdlib.__main__.main)
-
-        # unexpected argument
-        sys.argv = self.SYSARGV[:]
-        sys.argv += ["-v foo"]
-        sys.stderr = self.devnull
-        self.assertRaises(SystemExit, pyftpdlib.__main__.main)
+    def test_version_option(self):
+        for opt in ("-v", "--version"):
+            with self.assertRaises(SystemExit) as cm:
+                main([opt])
+            self.assertEqual(str(cm.exception), "pyftpdlib %s" % __ver__)
 
     def test_D_option(self):
         with mock.patch('pyftpdlib.__main__.config_logging') as fun:

--- a/pyftpdlib/test/test_misc.py
+++ b/pyftpdlib/test/test_misc.py
@@ -107,6 +107,15 @@ class TestCommandLineParser(PyftpdlibTestCase):
         with self.assertRaisesRegex(ValueError, "no such directory"):
             main(["-d", "?!?"])
 
+    def test_nat_address_opt(self):
+        ftpd = main(["-n", "127.0.0.1"])
+        self.assertEqual(ftpd.handler.masquerade_address, "127.0.0.1")
+        ftpd = main(["--nat-address", "127.0.0.1"])
+        self.assertEqual(ftpd.handler.masquerade_address, "127.0.0.1")
+        # without argument
+        with self.assertRaises(SystemExit):
+            main(["-n"])
+
     def test_r_option(self):
         sys.argv += ["-r 60000-61000", "-p", "0"]
         pyftpdlib.__main__.main()

--- a/pyftpdlib/test/test_misc.py
+++ b/pyftpdlib/test/test_misc.py
@@ -5,8 +5,6 @@
 import os
 import warnings
 
-from pyftpdlib.authorizers import DummyAuthorizer
-
 
 try:
     from StringIO import StringIO as BytesIO
@@ -18,6 +16,7 @@ from pyftpdlib import __ver__
 from pyftpdlib.__main__ import main
 from pyftpdlib._compat import PY3
 from pyftpdlib._compat import super
+from pyftpdlib.authorizers import DummyAuthorizer
 from pyftpdlib.servers import FTPServer
 from pyftpdlib.test import PyftpdlibTestCase
 
@@ -33,10 +32,7 @@ class TestCommandLineParser(PyftpdlibTestCase):
             serve_forever() to return immediately.
             """
 
-            started = False
-
             def serve_forever(self, *args, **kwargs):
-                self.started = True
                 return
 
         if PY3:

--- a/pyftpdlib/test/test_misc.py
+++ b/pyftpdlib/test/test_misc.py
@@ -56,6 +56,14 @@ class TestCommandLineParser(PyftpdlibTestCase):
         pyftpdlib.servers.FTPServer = self.original_ftpserver_class
         super().tearDown()
 
+    def test_interface_opt(self):
+        # no param
+        with self.assertRaises(SystemExit) as cm:
+            main(["-i"])
+        with self.assertRaises(SystemExit) as cm:
+            main(["--interface"])
+        ftpd = main(["--interface", "127.0.0.1"])
+
     def test_port_opt(self):
         # no param
         with self.assertRaises(SystemExit) as cm:

--- a/pyftpdlib/test/test_misc.py
+++ b/pyftpdlib/test/test_misc.py
@@ -136,6 +136,10 @@ class TestCommandLineParser(PyftpdlibTestCase):
                 main([opt])
             self.assertEqual(str(cm.exception), "pyftpdlib %s" % __ver__)
 
+    def test_verbose_option(self):
+        for opt in ("-V", "--verbose"):
+            main([opt])
+
     def test_D_option(self):
         with mock.patch('pyftpdlib.__main__.config_logging') as fun:
             sys.argv += ["-D", "-p 0"]

--- a/pyftpdlib/test/test_misc.py
+++ b/pyftpdlib/test/test_misc.py
@@ -2,9 +2,7 @@
 # Use of this source code is governed by MIT license that can be
 # found in the LICENSE file.
 
-import logging
 import os
-import sys
 import warnings
 
 from pyftpdlib.authorizers import DummyAuthorizer
@@ -22,7 +20,6 @@ from pyftpdlib._compat import PY3
 from pyftpdlib._compat import super
 from pyftpdlib.servers import FTPServer
 from pyftpdlib.test import PyftpdlibTestCase
-from pyftpdlib.test import mock
 
 
 class TestCommandLineParser(PyftpdlibTestCase):
@@ -130,6 +127,13 @@ class TestCommandLineParser(PyftpdlibTestCase):
         with self.assertRaises(SystemExit):
             main(["-r", "yyy-zzz"])
 
+    def test_debug_option(self):
+        main(["-D"])
+        main(["--debug"])
+        # without arg
+        with self.assertRaises(SystemExit):
+            main(["-D", "xxx"])
+
     def test_version_option(self):
         for opt in ("-v", "--version"):
             with self.assertRaises(SystemExit) as cm:
@@ -139,18 +143,6 @@ class TestCommandLineParser(PyftpdlibTestCase):
     def test_verbose_option(self):
         for opt in ("-V", "--verbose"):
             main([opt])
-
-    def test_D_option(self):
-        with mock.patch('pyftpdlib.__main__.config_logging') as fun:
-            sys.argv += ["-D", "-p 0"]
-            pyftpdlib.__main__.main()
-            fun.assert_called_once_with(level=logging.DEBUG)
-
-        # unexpected argument
-        sys.argv = self.SYSARGV[:]
-        sys.argv += ["-V foo"]
-        sys.stderr = self.devnull
-        self.assertRaises(SystemExit, pyftpdlib.__main__.main)
 
 
 if __name__ == '__main__':

--- a/pyftpdlib/test/test_misc.py
+++ b/pyftpdlib/test/test_misc.py
@@ -127,22 +127,28 @@ class TestCommandLineParser(PyftpdlibTestCase):
         with self.assertRaises(SystemExit):
             main(["-r", "yyy-zzz"])
 
-    def test_debug_option(self):
+    def test_debug_opt(self):
         main(["-D"])
         main(["--debug"])
-        # without arg
+        # with arg
         with self.assertRaises(SystemExit):
             main(["-D", "xxx"])
 
-    def test_version_option(self):
+    def test_version_opt(self):
         for opt in ("-v", "--version"):
             with self.assertRaises(SystemExit) as cm:
                 main([opt])
             self.assertEqual(str(cm.exception), "pyftpdlib %s" % __ver__)
 
-    def test_verbose_option(self):
+    def test_verbose_opt(self):
         for opt in ("-V", "--verbose"):
             main([opt])
+
+    def test_username_opt(self):
+        ftpd = main(["--username", "foo", "--password", "bar"])
+        self.assertTrue(
+            ftpd.handler.authorizer.has_user("foo"),
+        )
 
 
 if __name__ == '__main__':

--- a/pyftpdlib/test/test_misc.py
+++ b/pyftpdlib/test/test_misc.py
@@ -116,20 +116,18 @@ class TestCommandLineParser(PyftpdlibTestCase):
         with self.assertRaises(SystemExit):
             main(["-n"])
 
-    def test_r_option(self):
-        sys.argv += ["-r 60000-61000", "-p", "0"]
-        pyftpdlib.__main__.main()
+    def test_range_opt(self):
+        ftpd = main(["-r", "60000-61000"])
+        self.assertEqual(
+            ftpd.handler.passive_ports, list(range(60000, 61000 + 1))
+        )
 
         # without arg
-        sys.argv = self.SYSARGV[:]
-        sys.argv += ["-r"]
-        sys.stderr = self.devnull
-        self.assertRaises(SystemExit, pyftpdlib.__main__.main)
-
+        with self.assertRaises(SystemExit):
+            main(["-r"])
         # wrong arg
-        sys.argv = self.SYSARGV[:]
-        sys.argv += ["-r yyy-zzz"]
-        self.assertRaises(SystemExit, pyftpdlib.__main__.main)
+        with self.assertRaises(SystemExit):
+            main(["-r", "yyy-zzz"])
 
     def test_v_option(self):
         sys.argv += ["-v"]

--- a/pyftpdlib/test/test_misc.py
+++ b/pyftpdlib/test/test_misc.py
@@ -144,11 +144,14 @@ class TestCommandLineParser(PyftpdlibTestCase):
         for opt in ("-V", "--verbose"):
             main([opt])
 
-    def test_username_opt(self):
+    def test_username_and_password_opt(self):
         ftpd = main(["--username", "foo", "--password", "bar"])
         self.assertTrue(
             ftpd.handler.authorizer.has_user("foo"),
         )
+        # no --password
+        with self.assertRaises(SystemExit) as cm:
+            main(["--username", "foo"])
 
 
 if __name__ == '__main__':

--- a/scripts/ftpbench
+++ b/scripts/ftpbench
@@ -25,7 +25,6 @@ Example usages:
 """
 
 # Some benchmarks (Linux 3.0.0, Intel core duo - 3.1 Ghz).
-
 # pyftpdlib 1.0.0:
 #
 #   (starting with 6.7M of memory being used)
@@ -64,18 +63,21 @@ Example usages:
 #   300 concurrent clients (STOR 10.0M file)               9.74 secs    140.9M
 #   300 concurrent clients (QUIT)                          0.00 secs
 
+from __future__ import division
+from __future__ import print_function
 
-from __future__ import division, print_function
+import argparse
 import asynchat
 import asyncore
 import atexit
 import contextlib
 import ftplib
-import optparse
 import os
 import ssl
 import sys
 import time
+
+
 try:
     import resource
 except ImportError:
@@ -109,8 +111,10 @@ SSL_ERROR_WANT_WRITE = getattr(ssl, "SSL_ERROR_WANT_WRITE", object())
 
 
 if not sys.stdout.isatty() or os.name != 'posix':
+
     def hilite(s, *args, **kwargs):
         return s
+
 else:
     # http://goo.gl/6V8Rm
     def hilite(string, ok=True, bold=False):
@@ -118,9 +122,9 @@ else:
         attr = []
         if ok is None:  # no color
             pass
-        elif ok:   # green
+        elif ok:  # green
             attr.append('32')
-        else:   # red
+        else:  # red
             attr.append('31')
         if bold:
             attr.append('1')
@@ -128,9 +132,11 @@ else:
 
 
 def print_bench(what, value, unit=""):
-    s = "%s %s %-8s" % (hilite("%-50s" % what, ok=None, bold=0),
-                        hilite("%8.2f" % value),
-                        unit)
+    s = "%s %s %-8s" % (
+        hilite("%-50s" % what, ok=None, bold=0),
+        hilite("%8.2f" % value),
+        unit,
+    )
     if server_memory:
         s += "%s" % hilite(server_memory.pop())
     print(s.strip())
@@ -178,6 +184,7 @@ def register_memory():
     """Register an approximation of memory used by FTP server process
     and all of its children.
     """
+
     # XXX How to get a reliable representation of memory being used is
     # not clear. (rss - shared) seems kind of ok but we might also use
     # the private working set via get_memory_maps().private*.
@@ -200,22 +207,25 @@ def register_memory():
 
 
 def timethis(what):
-    """"Utility function for making simple benchmarks (calculates time calls).
+    """Utility function for making simple benchmarks (calculates time calls).
     It can be used either as a context manager or as a decorator.
     """
+
     @contextlib.contextmanager
     def benchmark():
         timer = time.clock if sys.platform == "win32" else time.time
         start = timer()
         yield
         stop = timer()
-        res = (stop - start)
+        res = stop - start
         print_bench(what, res, "secs")
 
-    if hasattr(what, "__call__"):
+    if callable(what):
+
         def timed(*args, **kwargs):
             with benchmark():
                 return what(*args, **kwargs)
+
         return timed
     else:
         return benchmark()
@@ -273,6 +283,7 @@ def bytes_per_second(ftp, retr=True):
     """Return the number of bytes transmitted in 1 second."""
     tot_bytes = 0
     if retr:
+
         def request_file():
             ftp.voidcmd('TYPE I')
             conn = ftp.transfercmd("retr " + TESTFN)
@@ -356,8 +367,10 @@ def bench_multi(howmany):
 
     def bench_multi_retr(clients):
         stor(clients[0])
-        with timethis("%s concurrent clients (RETR %s file)" % (
-                howmany, bytes2human(FILE_SIZE))):
+        with timethis(
+            "%s concurrent clients (RETR %s file)"
+            % (howmany, bytes2human(FILE_SIZE))
+        ):
             for ftp in clients:
                 ftp.voidcmd('TYPE I')
                 conn = ftp.transfercmd("RETR " + TESTFN)
@@ -368,8 +381,10 @@ def bench_multi(howmany):
             ftp.voidresp()
 
     def bench_multi_stor(clients):
-        with timethis("%s concurrent clients (STOR %s file)" % (
-                howmany, bytes2human(FILE_SIZE))):
+        with timethis(
+            "%s concurrent clients (STOR %s file)"
+            % (howmany, bytes2human(FILE_SIZE))
+        ):
             for ftp in clients:
                 ftp.voidcmd('TYPE I')
                 conn = ftp.transfercmd("STOR " + TESTFN)
@@ -470,75 +485,105 @@ class AsyncQuit(asynchat.async_chat):
         raise
 
 
-class OptFormatter(optparse.IndentedHelpFormatter):
-
-    def format_epilog(self, s):
-        return s.lstrip()
-
-    def format_option(self, option):
-        result = []
-        opts = self.option_strings[option]
-        result.append('  %s\n' % opts)
-        if option.help:
-            help_text = '     %s\n\n' % self.expand_default(option)
-            result.append(help_text)
-        return ''.join(result)
-
-
 def main():
-    global HOST, PORT, USER, PASSWORD, SERVER_PROC, TIMEOUT, SSL, FILE_SIZE, \
-        DEBUG
-    USAGE = "%s -u USERNAME -p PASSWORD [-H] [-P] [-b] [-n] [-s] [-k] " \
-            "[-t] [-d] [-S]" % (os.path.basename(__file__))
-    parser = optparse.OptionParser(usage=USAGE,
-                                   epilog=__doc__[__doc__.find('Example'):],
-                                   formatter=OptFormatter())
-    parser.add_option('-u', '--user', dest='user', help='username')
-    parser.add_option('-p', '--pass', dest='password', help='password')
-    parser.add_option('-H', '--host', dest='host', default=HOST,
-                      help='hostname')
-    parser.add_option('-P', '--port', dest='port', default=PORT, help='port',
-                      type=int)
-    parser.add_option('-b', '--benchmark', dest='benchmark',
-                      default='transfer',
-                      help="benchmark type ('transfer', 'download', 'upload', "
-                           "'concurrence', 'all')")
-    parser.add_option('-n', '--clients', dest='clients', default=200,
-                      type="int",
-                      help="number of concurrent clients used by "
-                           "'concurrence' benchmark")
-    parser.add_option('-s', '--filesize', dest='filesize', default="10M",
-                      help="file size used by 'concurrence' benchmark "
-                           "(e.g. '10M')")
-    parser.add_option('-k', '--pid', dest='pid', default=None, type="int",
-                      help="the PID of the FTP server process, to track its "
-                           "memory usage")
-    parser.add_option('-t', '--timeout', dest='timeout',
-                      default=TIMEOUT, type="int", help="the socket timeout")
-    parser.add_option('-d', '--debug', action='store_true', dest='debug',
-                      help="whether to print debugging info")
-    parser.add_option('-S', '--ssl', action='store_true', dest='ssl',
-                      help="whether to use FTPS")
+    global HOST, PORT, USER, PASSWORD, SERVER_PROC, TIMEOUT, SSL, FILE_SIZE, DEBUG
 
-    options, args = parser.parse_args()
-    if not options.user or not options.password:
-        sys.exit(USAGE)
-    else:
-        USER = options.user
-        PASSWORD = options.password
-        HOST = options.host
-        PORT = options.port
-        TIMEOUT = options.timeout
-        SSL = bool(options.ssl)
-        DEBUG = options.debug
-        try:
-            FILE_SIZE = human2bytes(options.filesize)
-        except (ValueError, AssertionError):
-            parser.error("invalid file size %r" % options.filesize)
-        if options.pid is not None:
-            if psutil is None:
-                raise ImportError("-p option requires psutil module")
-            SERVER_PROC = psutil.Process(options.pid)
+    USAGE = (
+        "%s -u USERNAME -p PASSWORD [-H] [-P] [-b] [-n] [-s] [-k] "
+        "[-t] [-d] [-S]" % (os.path.basename(__file__))
+    )
+
+    parser = argparse.ArgumentParser(
+        usage=USAGE,
+    )
+
+    parser.add_argument(
+        '-u', '--user', dest='user', required=True, help='username'
+    )
+    parser.add_argument(
+        '-p', '--pass', dest='password', required=True, help='password'
+    )
+    parser.add_argument(
+        '-H', '--host', dest='host', default=HOST, help='hostname'
+    )
+    parser.add_argument(
+        '-P', '--port', dest='port', default=PORT, type=int, help='port'
+    )
+    parser.add_argument(
+        '-b',
+        '--benchmark',
+        dest='benchmark',
+        default='transfer',
+        help=(
+            "benchmark type ('transfer', 'download', 'upload', 'concurrence',"
+            " 'all')"
+        ),
+    )
+    parser.add_argument(
+        '-n',
+        '--clients',
+        dest='clients',
+        default=200,
+        type=int,
+        help="number of concurrent clients used by 'concurrence' benchmark",
+    )
+    parser.add_argument(
+        '-s',
+        '--filesize',
+        dest='filesize',
+        default="10M",
+        help="file size used by 'concurrence' benchmark (e.g. '10M')",
+    )
+    parser.add_argument(
+        '-k',
+        '--pid',
+        dest='pid',
+        default=None,
+        type=int,
+        help="the PID of the FTP server process, to track its memory usage",
+    )
+    parser.add_argument(
+        '-t',
+        '--timeout',
+        dest='timeout',
+        default=TIMEOUT,
+        type=int,
+        help="the socket timeout",
+    )
+    parser.add_argument(
+        '-d',
+        '--debug',
+        action='store_true',
+        dest='debug',
+        help="whether to print debugging info",
+    )
+    parser.add_argument(
+        '-S',
+        '--ssl',
+        action='store_true',
+        dest='ssl',
+        help="whether to use FTPS",
+    )
+
+    options = parser.parse_args()
+
+    USER = options.user
+    PASSWORD = options.password
+    HOST = options.host
+    PORT = options.port
+    TIMEOUT = options.timeout
+    SSL = options.ssl
+    DEBUG = options.debug
+
+    try:
+        FILE_SIZE = human2bytes(options.filesize)
+    except (ValueError, AssertionError):
+        parser.error("invalid file size %r" % options.filesize)
+
+    if options.pid is not None:
+        if psutil is None:
+            raise ImportError("-k option requires psutil module")
+        SERVER_PROC = psutil.Process(options.pid)
 
     # before starting make sure we have write permissions
     ftp = connect()
@@ -552,8 +597,11 @@ def main():
     # start benchmark
     if SERVER_PROC is not None:
         register_memory()
-        print("(starting with %s of memory being used)" % (
-            hilite(server_memory.pop())))
+        print(
+            "(starting with %s of memory being used)"
+            % (hilite(SERVER_PROC.memory_info().rss))
+        )
+
     if options.benchmark == 'download':
         stor()
         bench_retr()


### PR DESCRIPTION
Reason: optparse module was deprecated in python 3.2.