### PR TITLE
Add `FTPHandler.encoding` option

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ Version: 2.0.0 - (IN DEVELOPMENT)
 
 **Enhancements**
 
+* #625: exposed a new ``FTPHandler.encoding`` attribute defaulting to
+  ``'utf-8'``. It can be used to change the encoding used for client / server
+  communication.
 * #629: removed Python 2.7 support.
 * #637: remove copies of asyncore.py and asynchat.py. Use backports from PYPI
   instead.  (patch by @penguinpee)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -222,7 +222,12 @@ Control connection
     `pysendfile <https://github.com/giampaolo/pysendfile>`__ module to be
     installed separately.
 
-    *New in version 0.7.0*
+  .. data:: encoding
+
+    The encoding used for client / server communication. Defaults to
+    ``'utf-8'``.
+
+    *New in version 2.0.0*
 
   .. data:: auth_failed_timeout
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -222,6 +222,8 @@ Control connection
     `pysendfile <https://github.com/giampaolo/pysendfile>`__ module to be
     installed separately.
 
+    *New in version 0.7.0*
+
   .. data:: encoding
 
     The encoding used for client / server communication. Defaults to

--- a/pyftpdlib/filesystems.py
+++ b/pyftpdlib/filesystems.py
@@ -476,7 +476,9 @@ class AbstractedFS:
                 mtimestr,
                 basename,
             )
-            yield line.encode('utf8', self.cmd_channel.unicode_errors)
+            yield line.encode(
+                self.cmd_channel.encoding, self.cmd_channel.unicode_errors
+            )
 
     def format_mlsx(self, basedir, listing, perms, facts, ignore_err=True):
         """Return an iterator object that yields the entries of a given
@@ -597,7 +599,9 @@ class AbstractedFS:
                 [f"{x}={retfacts[x]};" for x in sorted(retfacts.keys())]
             )
             line = f"{factstring} {basename}\r\n"
-            yield line.encode('utf8', self.cmd_channel.unicode_errors)
+            yield line.encode(
+                self.cmd_channel.encoding, self.cmd_channel.unicode_errors
+            )
 
 
 # ===================================================================

--- a/pyftpdlib/test/__init__.py
+++ b/pyftpdlib/test/__init__.py
@@ -379,6 +379,7 @@ def reset_server_opts():
         klass.use_sendfile = hasattr(os, "sendfile")
         klass.ac_in_buffer_size = 4096
         klass.ac_out_buffer_size = 4096
+        klass.encoding = "utf8"
         if klass.__name__ == 'TLS_FTPHandler':
             klass.tls_control_required = False
             klass.tls_data_required = False

--- a/pyftpdlib/test/test_functional.py
+++ b/pyftpdlib/test/test_functional.py
@@ -1693,6 +1693,7 @@ class TestConfigurableOptions(PyftpdlibTestCase):
             self.server.handler.passive_ports = None
             self.server.handler.use_gmt_times = True
             self.server.handler.tcp_no_delay = hasattr(socket, 'TCP_NODELAY')
+            self.server.handler.encoding = "utf8"
             self.server.stop()
         super().tearDown()
 
@@ -1906,6 +1907,16 @@ class TestConfigurableOptions(PyftpdlibTestCase):
             assert gmt1 == loc1
             assert gmt2 == loc2
             assert gmt3 == loc3
+
+    def test_encoding(self):
+        # Make sure that if encoding != UTF-8, FEAT command does not
+        # list UTF-8.
+        self.server = self.server_class()
+        self.server.handler.encoding = "latin-1"
+        self.server.start()
+        self.connect()
+        resp = self.client.sendcmd('feat')
+        assert 'UTF8' not in resp
 
 
 @pytest.mark.xdist_group(name="serial")


### PR DESCRIPTION
In order to support https://github.com/giampaolo/pyftpdlib/issues/625.
I'm doing this now AFTER we removed Python 2.X support, a step which was necessary to implement this relatively easily.