### PR TITLE
Py313 win

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,10 @@ Version: 2.1.0 - (IN DEVELOPMENT)
   for local development. They can also be installed via ``pip install .[test]``
   and ``pip install .[dev]``.
 
+**Bug fixes**
+
+* #650: file operations on Windows with Python 3.13 give "Permission denied".
+
 Version: 2.0.0 - 2024-09-04
 ===========================
 


### PR DESCRIPTION
Fixes https://github.com/giampaolo/pyftpdlib/issues/650. 

Starting from Python 3.13, `os.path.isabs("/foo")` on Windows return `False`. This causes many file operations on Windows to fail with "Permission denied". This PR makes `os.path.isabs()` on Windows behave like in Python <= 3.12.