### PR TITLE
Avoid the multiprocessing forkserver method

### DIFF
--- a/pyftpdlib/servers.py
+++ b/pyftpdlib/servers.py
@@ -579,6 +579,13 @@ if os.name == 'posix':
 
             _lock = multiprocessing.Lock()
             _exit = multiprocessing.Event()
+            # Python 3.14 changed the non-macOS POSIX default to forkserver
+            # but the code in this module does not work with it
+            # See https://github.com/python/cpython/issues/125714
+            if multiprocessing.get_start_method() == 'forkserver':
+                _mp_context = multiprocessing.get_context(method='fork')
+            else:
+                _mp_context = multiprocessing.get_context()
 
             def _start_task(self, *args, **kwargs):
-                return multiprocessing.Process(*args, **kwargs)
+                return self._mp_context.Process(*args, **kwargs)


### PR DESCRIPTION
Python 3.14 changed the default multiprocessing method for POSIX (sans macOS) from fork to forkserver. This causes errors like:

    TypeError: cannot pickle 'select.epoll' object
    when serializing dict item '_poller'
    when serializing pyftpdlib.ioloop.Epoll state
    when serializing pyftpdlib.ioloop.Epoll object
    when serializing dict item 'ioloop'
    when serializing pyftpdlib.servers.MultiprocessFTPServer state
    when serializing pyftpdlib.servers.MultiprocessFTPServer object
    when serializing tuple item 0
    when serializing method reconstructor arguments
    when serializing method object
    when serializing dict item '_target'
    when serializing multiprocessing.context.Process state
    when serializing multiprocessing.context.Process object

See https://github.com/python/cpython/issues/125714