### PR TITLE
fix socket fd reclose

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -604,6 +604,7 @@ class ActiveDTP(Connector):
     def handle_connect(self):
         """Called when connection is established."""
         self.del_channel()
+        self._fileno = None
         if self._idler is not None and not self._idler.cancelled:
             self._idler.cancel()
         if not self.cmd_channel.connected:


### PR DESCRIPTION
When both active mode and passive mode are using data channels, the socket fd used to establish the connection in active mode is not released, which will cause the socket fd reused by the data channel in passive mode to be closed by mistake when the user logs out, resulting in data writing failure.

This pull request includes a small change to the `pyftpdlib/handlers.py` file. The change modifies the `handle_connect` method to set `_fileno` to `None` when the connection is established.

* [`pyftpdlib/handlers.py`](diffhunk://#diff-7beb3c3c871bc90098911789ef68367be5aeb255ca51b6668a54730a16d8b7b9R607): Modified the `handle_connect` method to set `_fileno` to `None` when the connection is established.