### PR TITLE
replace chdir with permission check on ftp_CWD

### DIFF
--- a/pyftpdlib/filesystems.py
+++ b/pyftpdlib/filesystems.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by MIT license that can be
 # found in the LICENSE file.
 
+import errno
 import os
 import stat
 import tempfile
@@ -258,8 +259,10 @@ class AbstractedFS:
         """Change the current directory. If this method is overridden
         it is vital that `cwd` attribute gets set.
         """
-        # note: process cwd will be reset by the caller
-        os.chdir(path)
+        is_dir = stat.S_ISDIR(os.stat(path).st_mode)
+        if not is_dir or not os.access(path, os.R_OK | os.X_OK):
+            code = errno.EACCES if is_dir else errno.ENOTDIR
+            raise OSError(code, os.strerror(code), path)
         self.cwd = self.fs2ftp(path)
 
     def mkdir(self, path):

--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -2759,14 +2759,11 @@ class FTPHandler(AsyncChat):
         """Change the current working directory.
         On success return the new directory path, else None.
         """
-        # Temporarily join the specified directory to see if we have
-        # permissions to do so, then get back to original process's
-        # current working directory.
+        # Check permissions for the specified directory and set it as cwd.
         # Note that if for some reason os.getcwd() gets removed after
         # the process is started we'll get into troubles (os.getcwd()
         # will fail with ENOENT) but we can't do anything about that
         # except logging an error.
-        init_cwd = os.getcwd()
         try:
             self.run_as_current_user(self.fs.chdir, path)
         except (OSError, FilesystemError) as err:
@@ -2775,8 +2772,6 @@ class FTPHandler(AsyncChat):
         else:
             cwd = self.fs.cwd
             self.respond(f'250 "{cwd}" is the current directory.')
-            if os.getcwd() != init_cwd:
-                os.chdir(init_cwd)
             return path
 
     def ftp_CDUP(self, path):


### PR DESCRIPTION
Perform directory permission check instead of `chdir`, addressing #475 and #483 .

An user of my application found that stressing pyftpdlib ftp_CWD calls can lead to race conditions ( https://gitlab.com/ergoithz/umftpd/-/issues/7 ) which shouldn't be theoretically possible using ioloop (might be a n issue in cpython), but regardless of the reason, `chdir` being global is itself problematic, this PR addresses that.

As a side note, the full POSIX equivalent to `os.chdir` would be `os.close(os.open(path, os.R_OK | os.O_DIRECTORY))`, but it's 2x slower and not portable, so I'm checking access and inode type instead (which isn't substantially slower than `os.chdir` in my testing).
