### PR TITLE
allow connecting from IPv6 link-local addresses

### DIFF
--- a/pyftpdlib/handlers.py
+++ b/pyftpdlib/handlers.py
@@ -405,7 +405,8 @@ class PassiveDTP(Acceptor):
         self.log_exception = cmd_channel.log_exception
         Acceptor.__init__(self, ioloop=cmd_channel.ioloop)
 
-        local_ip = self.cmd_channel.socket.getsockname()[0]
+        sockname = list(self.cmd_channel.socket.getsockname())
+        local_ip = sockname[0]
         if local_ip in self.cmd_channel.masquerade_address_map:
             masqueraded_ip = self.cmd_channel.masquerade_address_map[local_ip]
         elif self.cmd_channel.masquerade_address:
@@ -413,7 +414,10 @@ class PassiveDTP(Acceptor):
         else:
             masqueraded_ip = None
 
-        if self.cmd_channel.server.socket.family != socket.AF_INET:
+        if local_ip.startswith('fe') and local_ip[2:3] in "89ab":
+            # IPv6 link-local
+            af = socket.AF_INET6
+        elif self.cmd_channel.server.socket.family != socket.AF_INET:
             # dual stack IPv4/IPv6 support
             af = self.bind_af_unspecified((local_ip, 0))
             self.socket.close()
@@ -426,14 +430,16 @@ class PassiveDTP(Acceptor):
         if self.cmd_channel.passive_ports is None:
             # By using 0 as port number value we let kernel choose a
             # free unprivileged random port.
-            self.bind((local_ip, 0))
+            sockname[1] = 0
+            self.bind(tuple(sockname))
         else:
             ports = list(self.cmd_channel.passive_ports)
             while ports:
                 port = ports.pop(random.randint(0, len(ports) - 1))
                 self.set_reuse_addr()
+                sockname[1] = port
                 try:
-                    self.bind((local_ip, port))
+                    self.bind(tuple(sockname))
                 except PermissionError:
                     self.cmd_channel.log(
                         f"ignoring EPERM when bind()ing port {port}",
@@ -449,7 +455,8 @@ class PassiveDTP(Acceptor):
                         # By using 0 as port number value we let kernel
                         # choose a free unprivileged random port.
                         else:
-                            self.bind((local_ip, 0))
+                            sockname[1] = 0
+                            self.bind(tuple(sockname))
                             self.cmd_channel.log(
                                 "Can't find a valid passive port in the "
                                 "configured range. A random kernel-assigned "


### PR DESCRIPTION
this should fix #664, where clients would get rejected if they connected from a link-local IPv6-address (`fe80:` through `febf:`). I'm not sure if this is the optimal way to fix this, but I believe it is at least sound :-)

I didn't add a test for this, since I think it would require an IPv6 link-local address to connect from, and I'm not sure how to assign one without running the test as root.

The tests did not seem any worse for the wear on either Windows, Linux, or Macos -- on Linux I did have to replace `net_connections` with `connections` in `pyftpdlib/test/*.py` and on Macos there was a small number of seemingly unrelated issues; [pyftpdlib-test-macos.txt](https://github.com/user-attachments/files/21944265/pyftpdlib-test-macos.txt)